### PR TITLE
DirectX & CreateMove changes, fix TODO.

### DIFF
--- a/Fedoraware/Fedoraware-TF2/src/Core/Core.cpp
+++ b/Fedoraware/Fedoraware-TF2/src/Core/Core.cpp
@@ -81,7 +81,6 @@ void CCore::Unload()
 
 bool CCore::ShouldUnload()
 {
-	// to do: check if window is focused so that we don't unload using something else
 	const bool unloadKey = GetAsyncKeyState(VK_F11) & 0x8000;
-	return unloadKey && !F::Menu.IsOpen;
+	return unloadKey && !F::Menu.IsOpen && Utils::IsGameWindowInFocus();
 }

--- a/Fedoraware/Fedoraware-TF2/src/Hooks/Detours/ClientModeShared_CreateMove.cpp
+++ b/Fedoraware/Fedoraware-TF2/src/Hooks/Detours/ClientModeShared_CreateMove.cpp
@@ -27,8 +27,12 @@ MAKE_HOOK(ClientModeShared_CreateMove, Utils::GetVFuncPtr(I::ClientModeShared, 2
 	const auto& pWeapon = g_EntityCache.GetWeapon();
 
 	// Get the pointer to pSendPacket
-	uintptr_t _bp; __asm mov _bp, ebp;
-	auto pSendPacket = reinterpret_cast<bool*>(***reinterpret_cast<uintptr_t***>(_bp) - 0x1);
+	//uintptr_t _bp; __asm mov _bp, ebp;
+	//auto pSendPacket = reinterpret_cast<bool*>(***reinterpret_cast<uintptr_t***>(_bp) - 0x1);
+
+	// NOTE: Riley; Using inline assembly for this is unsafe.
+	auto bp = reinterpret_cast<uintptr_t>(_AddressOfReturnAddress()) - sizeof(void*);
+	auto pSendPacket = reinterpret_cast<bool*>(***reinterpret_cast<uintptr_t***>(bp) - 0x1);
 
 	//if (Vars::Misc::Game::NetworkFix.Value || Vars::Misc::Game::PredictionFix.Value)
 		I::Prediction->Update(I::ClientState->m_nDeltaTick, I::ClientState->m_nDeltaTick > 0, I::ClientState->last_command_ack, I::ClientState->lastoutgoingcommand + I::ClientState->chokedcommands);

--- a/Fedoraware/Fedoraware-TF2/src/Hooks/Detours/ClientModeShared_CreateMove.cpp
+++ b/Fedoraware/Fedoraware-TF2/src/Hooks/Detours/ClientModeShared_CreateMove.cpp
@@ -26,10 +26,6 @@ MAKE_HOOK(ClientModeShared_CreateMove, Utils::GetVFuncPtr(I::ClientModeShared, 2
 	const auto& pLocal = g_EntityCache.GetLocal();
 	const auto& pWeapon = g_EntityCache.GetWeapon();
 
-	// Get the pointer to pSendPacket
-	//uintptr_t _bp; __asm mov _bp, ebp;
-	//auto pSendPacket = reinterpret_cast<bool*>(***reinterpret_cast<uintptr_t***>(_bp) - 0x1);
-
 	// NOTE: Riley; Using inline assembly for this is unsafe.
 	auto bp = reinterpret_cast<uintptr_t>(_AddressOfReturnAddress()) - sizeof(void*);
 	auto pSendPacket = reinterpret_cast<bool*>(***reinterpret_cast<uintptr_t***>(bp) - 0x1);

--- a/Fedoraware/Fedoraware-TF2/src/Hooks/MenuHook/MenuHook.cpp
+++ b/Fedoraware/Fedoraware-TF2/src/Hooks/MenuHook/MenuHook.cpp
@@ -10,32 +10,13 @@ void MenuHook::Unload()
 	F::Menu.Unload = true;
 }
 
-MAKE_HOOK(Direct3DDevice9_EndScene, Utils::GetVFuncPtr(I::DirectXDevice, 42), HRESULT, __stdcall,
-	LPDIRECT3DDEVICE9 pDevice)
+MAKE_HOOK(Direct3DDevice9_Present, Utils::GetVFuncPtr(I::DirectXDevice, 17), HRESULT,
+	__stdcall, IDirect3DDevice9* pDevice, const RECT* pSource, const RECT* pDestination, HWND hWindowOverride,
+	const RGNDATA* pDirtyRegion)
 {
-	static void* fRegularAddr = 0, *fOverlayAddr = 0;
-	if (!fRegularAddr || !fOverlayAddr)
-	{
-		MEMORY_BASIC_INFORMATION info;
-		VirtualQuery(_ReturnAddress(), &info, sizeof(MEMORY_BASIC_INFORMATION));
-
-		char mod[MAX_PATH];
-		GetModuleFileNameA((HMODULE)info.AllocationBase, mod, MAX_PATH);
-
-		if (strstr(mod, "bin\\shaderapidx9.dll"))
-			fRegularAddr = _ReturnAddress();
-		else
-			fOverlayAddr = _ReturnAddress();
-	}
-
-	// proof of concept, frankly would like to keep surface in use
-	//if (!Vars::Visuals::AntiOBS.Value ? (fRegularAddr && fRegularAddr != _ReturnAddress()) : (fOverlayAddr && fOverlayAddr != _ReturnAddress()))
-	if (fRegularAddr && fRegularAddr != _ReturnAddress())
-		return Hook.Original<FN>()(pDevice);
-
 	F::Menu.Render(pDevice);
 
-	return Hook.Original<FN>()(pDevice);
+	return Hook.Original<FN>()(pDevice, pSource, pDestination, hWindowOverride, pDirtyRegion);
 }
 
 MAKE_HOOK(Direct3DDevice9_Reset, Utils::GetVFuncPtr(I::DirectXDevice, 16), HRESULT, __stdcall,


### PR DESCRIPTION
In Source Engine, EndScene is called twice. This causes whatever we draw in this hook to be rendered twice. However, Present is only called once. This then removes our need to do a ReturnAddress and also improves performance (it also majorly cleans up the hook).

CreateMove was changed from inline assembly to a ReturnAddress check as it's safer and should be compliant for 64-bit when it releases.